### PR TITLE
Fix some pep8 in test_alphaanglefeaturizer.py

### DIFF
--- a/msmbuilder/tests/test_alphaanglefeaturizer.py
+++ b/msmbuilder/tests/test_alphaanglefeaturizer.py
@@ -1,41 +1,36 @@
-import numpy as np
-from mdtraj.testing import eq, raises
 import msmbuilder.featurizer
 from msmbuilder.example_datasets import fetch_alanine_dipeptide
 from msmbuilder.example_datasets import fetch_fs_peptide
 
 
 def test_alanine_dipeptide():
-        # will produce 0 features because not enough peptides
+    # will produce 0 features because not enough peptides
 
-        dataset = fetch_alanine_dipeptide()
-        trajectories = dataset["trajectories"]
-        trj0 = trajectories[0][0]
-        featurizer = msmbuilder.featurizer.AlphaAngleFeaturizer()
-        nothing = featurizer.transform(trajectories)
+    dataset = fetch_alanine_dipeptide()
+    trajectories = dataset["trajectories"]
+    featurizer = msmbuilder.featurizer.AlphaAngleFeaturizer()
+    nothing = featurizer.transform(trajectories)
 
-        assert(nothing[0].shape[1] == 0)
+    assert(nothing[0].shape[1] == 0)
 
 
 def test_fs_peptide():
-        # will produce 36 features
+    # will produce 36 features
 
-        dataset = fetch_fs_peptide()
-        trajectories = dataset["trajectories"]
-        trj0 = trajectories[0][0]
-        featurizer = msmbuilder.featurizer.AlphaAngleFeaturizer()
-        alphas = featurizer.transform(trajectories)
+    dataset = fetch_fs_peptide()
+    trajectories = dataset["trajectories"]
+    featurizer = msmbuilder.featurizer.AlphaAngleFeaturizer()
+    alphas = featurizer.transform(trajectories)
 
-        assert(alphas[0].shape[1] == 36)
+    assert(alphas[0].shape[1] == 36)
 
 
 def test_fs_peptide_nosincos():
-        # will produce 18 features
+    # will produce 18 features
 
-        dataset = fetch_fs_peptide()
-        trajectories = dataset["trajectories"]
-        trj0 = trajectories[0][0]
-        featurizer = msmbuilder.featurizer.AlphaAngleFeaturizer(sincos=False)
-        alphas = featurizer.transform(trajectories)
+    dataset = fetch_fs_peptide()
+    trajectories = dataset["trajectories"]
+    featurizer = msmbuilder.featurizer.AlphaAngleFeaturizer(sincos=False)
+    alphas = featurizer.transform(trajectories)
 
-        assert(alphas[0].shape[1] == 18)
+    assert(alphas[0].shape[1] == 18)

--- a/msmbuilder/tests/test_alphaanglefeaturizer.py
+++ b/msmbuilder/tests/test_alphaanglefeaturizer.py
@@ -2,44 +2,40 @@ import numpy as np
 from mdtraj.testing import eq, raises
 import msmbuilder.featurizer
 from msmbuilder.example_datasets import fetch_alanine_dipeptide
-
-def test_alanine_dipeptide():
-	# will produce 0 features because not enough peptides
-
-	dataset = fetch_alanine_dipeptide()
-	trajectories = dataset["trajectories"]
-	trj0 = trajectories[0][0]
-	featurizer = msmbuilder.featurizer.AlphaAngleFeaturizer()
-	nothing = featurizer.transform(trajectories)
-
-	assert(nothing[0].shape[1] == 0)
-
 from msmbuilder.example_datasets import fetch_fs_peptide
 
+
+def test_alanine_dipeptide():
+        # will produce 0 features because not enough peptides
+
+        dataset = fetch_alanine_dipeptide()
+        trajectories = dataset["trajectories"]
+        trj0 = trajectories[0][0]
+        featurizer = msmbuilder.featurizer.AlphaAngleFeaturizer()
+        nothing = featurizer.transform(trajectories)
+
+        assert(nothing[0].shape[1] == 0)
+
+
 def test_fs_peptide():
-	# will produce 36 features
+        # will produce 36 features
 
-	dataset = fetch_fs_peptide()
-	trajectories = dataset["trajectories"]
-	trj0 = trajectories[0][0]
-	featurizer = msmbuilder.featurizer.AlphaAngleFeaturizer()
-	alphas = featurizer.transform(trajectories)
+        dataset = fetch_fs_peptide()
+        trajectories = dataset["trajectories"]
+        trj0 = trajectories[0][0]
+        featurizer = msmbuilder.featurizer.AlphaAngleFeaturizer()
+        alphas = featurizer.transform(trajectories)
 
-	assert(alphas[0].shape[1] == 36)
+        assert(alphas[0].shape[1] == 36)
+
 
 def test_fs_peptide_nosincos():
-	# will produce 18 features
+        # will produce 18 features
 
-	dataset = fetch_fs_peptide()
-	trajectories = dataset["trajectories"]
-	trj0 = trajectories[0][0]
-	featurizer = msmbuilder.featurizer.AlphaAngleFeaturizer(sincos=False)
-	alphas = featurizer.transform(trajectories)
+        dataset = fetch_fs_peptide()
+        trajectories = dataset["trajectories"]
+        trj0 = trajectories[0][0]
+        featurizer = msmbuilder.featurizer.AlphaAngleFeaturizer(sincos=False)
+        alphas = featurizer.transform(trajectories)
 
-	assert(alphas[0].shape[1] == 18)
-
-
-
-
-
-
+        assert(alphas[0].shape[1] == 18)


### PR DESCRIPTION
I ran the `pep8` and `flake8` checkers (install with `conda install pep8 flake8`, or `pip install flake8`, see http://flake8.readthedocs.org/en/latest/). The output is pasted below. Mostly, fixing stuff like this is pretty mechanical.
- You can also probably reconfigure your editor to never use tabs. In sublime, I think the setting is called "soft tabs". Since python uses indentation for nesting (instead of curly braces like many languages), anytime both tabs and spaces get used in the same file it becomes a total mess. So the general style is to never use tabs.
- Also, we usually put all of the imports at the top of the file, before any of the functions are defined.

```
$ pep8 msmbuilder/tests/test_alphaanglefeaturizer.py
msmbuilder/tests/test_alphaanglefeaturizer.py:9:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:11:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:12:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:13:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:14:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:15:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:17:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:21:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:23:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:24:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:25:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:26:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:27:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:29:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:33:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:35:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:36:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:37:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:38:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:39:1: W191 indentation contains tabs
msmbuilder/tests/test_alphaanglefeaturizer.py:41:1: W191 indentation contains tabs
```

```
$ flake8 msmbuilder/tests/test_alphaanglefeaturizer.py
msmbuilder/tests/test_alphaanglefeaturizer.py:1:1: F401 'np' imported but unused
msmbuilder/tests/test_alphaanglefeaturizer.py:2:1: F401 'eq' imported but unused
msmbuilder/tests/test_alphaanglefeaturizer.py:2:1: F401 'raises' imported but unused
msmbuilder/tests/test_alphaanglefeaturizer.py:13:9: F841 local variable 'trj0' is assigned to but never used
msmbuilder/tests/test_alphaanglefeaturizer.py:25:9: F841 local variable 'trj0' is assigned to but never used
msmbuilder/tests/test_alphaanglefeaturizer.py:37:9: F841 local variable 'trj0' is assigned to but never used
```
